### PR TITLE
Fix: Use before_install and install sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,13 @@ matrix:
   allow_failures:
     - php: hhvm
 
-## Update composer and run the appropriate composer command
-before_script:
+## Update composer and configure authentication token
+before_install:
   - composer self-update
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
+
+## Install or update dependencies
+install:
   - if [ -z "$dependencies" ]; then composer install; fi;
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update -n; fi;


### PR DESCRIPTION
This PR
- [x] updates and configures `composer` in the `before_install` section
- [x] installs or updates dependencies in the `install` section

:information_desk_person: For reference, see https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle.
