### PR TITLE
Fix: Require packages using --sort-packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
   ],
   "require": {
     "php": "^7.0",
-    "guzzlehttp/guzzle": "^5.0|^6.0",
     "aws/aws-sdk-php": "^3.0",
+    "guzzlehttp/guzzle": "^5.0|^6.0",
     "react/promise": "^2.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.0",
-    "vectorface/dunit": "~2.0",
-    "squizlabs/php_codesniffer": "^1.5.6"
+    "squizlabs/php_codesniffer": "^1.5.6",
+    "vectorface/dunit": "~2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "387fba5b68dd9ab67a0ec0df9e502c13",
-    "content-hash": "0a8f35f7333dd7667910aa10911fc5b6",
+    "hash": "401766a843e01b0a3e502ca219f1de2c",
+    "content-hash": "36c3b721ca2878469e36954131389b8e",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -614,16 +614,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "64d40a593fc31a8abf4ce3d200147ddf8ca64e52"
+                "reference": "92f5c61b5c64159faec5298325ffab0c7e59dcc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/64d40a593fc31a8abf4ce3d200147ddf8ca64e52",
-                "reference": "64d40a593fc31a8abf4ce3d200147ddf8ca64e52",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/92f5c61b5c64159faec5298325ffab0c7e59dcc8",
+                "reference": "92f5c61b5c64159faec5298325ffab0c7e59dcc8",
                 "shasum": ""
             },
             "require": {
@@ -632,7 +632,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-token-stream": "~1.3",
                 "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
@@ -672,7 +672,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-01-11 10:05:34"
+            "time": "2016-02-04 13:05:19"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1472,16 +1472,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "3df409958a646dad2bc5046c3fb671ee24a1a691"
+                "reference": "3cf0709d7fe936e97bee9e954382e449003f1d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3df409958a646dad2bc5046c3fb671ee24a1a691",
-                "reference": "3df409958a646dad2bc5046c3fb671ee24a1a691",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3cf0709d7fe936e97bee9e954382e449003f1d9a",
+                "reference": "3cf0709d7fe936e97bee9e954382e449003f1d9a",
                 "shasum": ""
             },
             "require": {
@@ -1517,7 +1517,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-26 13:39:53"
+            "time": "2016-02-02 13:44:19"
         },
         {
             "name": "vectorface/dunit",


### PR DESCRIPTION
This PR
- [x] requires packages using the `--sort-packages` option

:information_desk_person: It's easier to find items in list when the list is sorted, what do you think?

For reference, see https://getcomposer.org/doc/03-cli.md#require:

> **--sort-packages**: Keep packages sorted in composer.json.
