### PR TITLE
Fix: Prefer packages to be installed / updated with --prefer-dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ before_install:
 
 ## Install or update dependencies
 install:
-  - if [ -z "$dependencies" ]; then composer install; fi;
-  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
-  - if [ "$dependencies" = "highest" ]; then composer update -n; fi;
+  - if [ -z "$dependencies" ]; then composer install --prefer-dist; fi;
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
+  - if [ "$dependencies" = "highest" ]; then composer update --prefer-dist -n; fi;
   - composer show -i
 
 ## Run the actual test


### PR DESCRIPTION
This PR
- [x] uses `--prefer-dist` when installing packages with `composer`
