### PR TITLE
Fix: Rename Travis to ApiClient

### DIFF
--- a/examples/last-10-builds-async.php
+++ b/examples/last-10-builds-async.php
@@ -8,7 +8,7 @@ use WyriHaximus\React\GuzzlePsr7\HttpClientAdapter;
 use WyriHaximus\Travis\BuildCollection;
 use WyriHaximus\Travis\Builds;
 use WyriHaximus\Travis\Client;
-use WyriHaximus\Travis\Travis;
+use WyriHaximus\Travis\ApiClient;
 
 require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
 
@@ -17,7 +17,7 @@ $loop = Factory::create();
 $client = new Client(new GuzzleHandler(new GuzzleClient([
     'handler' => HandlerStack::create(new HttpClientAdapter($loop)),
 ])));
-$travis = new Travis($client);
+$travis = new ApiClient($client);
 $travis->repository('WyriHaximus/php-travis-client')->builds()->then(function (BuildCollection $builds) {
     foreach ($builds as $build) {
         //echo 'Build: #', $build->getId(), PHP_EOL;

--- a/examples/last-10-builds.php
+++ b/examples/last-10-builds.php
@@ -1,12 +1,12 @@
 <?php
 
 use WyriHaximus\Travis\Client;
-use WyriHaximus\Travis\Travis;
+use WyriHaximus\Travis\ApiClient;
 
 require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor/autoload.php';
 
 $client = new Client();
-$travis = new Travis($client);
+$travis = new ApiClient($client);
 
 foreach ($travis->repository('WyriHaximus/php-travis-client')->builds() as $build) {
     echo 'Build: #', $build->getId(), PHP_EOL;

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -5,7 +5,7 @@ namespace WyriHaximus\Travis;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class Travis implements EndpointInterface
+class ApiClient implements EndpointInterface
 {
     use ClientAwareTrait;
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -14,7 +14,7 @@ class Repository implements EndpointInterface
      */
     protected $repository;
 
-    public function __construct(Travis $parent, string $repository)
+    public function __construct(ApiClient $parent, string $repository)
     {
         $this->setParent($parent);
         $this->repository = $repository;


### PR DESCRIPTION
This PR
- [x] renames `Travis\Travis` to `Travis\ApiClient`

Follows #11.
