### PR TITLE
Enhancement: Implement Build as a value object

### DIFF
--- a/src/Resource/Build.php
+++ b/src/Resource/Build.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace WyriHaximus\Travis\Resource;
+
+use DateTimeInterface;
+
+final class Build implements BuildInterface
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var int
+     */
+    private $repositoryId;
+
+    /**
+     * @var int
+     */
+    private $commitId;
+
+    /**
+     * @var string
+     */
+    private $number;
+
+    /**
+     * @var bool
+     */
+    private $pullRequest;
+
+    /**
+     * @var string
+     */
+    private $pullRequestTitle;
+
+    /**
+     * @var string
+     */
+    private $pullRequestNumber;
+
+    /**
+     * @var array
+     */
+    private $config = [];
+
+    /**
+     * @var string
+     */
+    private $state;
+
+    /**
+     * @var DateTimeInterface
+     */
+    private $startedAt;
+
+    /**
+     * @var DateTimeInterface
+     */
+    private $finishedAt;
+
+    /**
+     * @var int
+     */
+    private $duration;
+
+    /**
+     * @var int[]
+     */
+    private $jobIds = [];
+
+    public function id() : int
+    {
+        return $this->id;
+    }
+
+    public function repositoryId() : int
+    {
+        return $this->repositoryId;
+    }
+
+    public function commitId() : int
+    {
+        return $this->commitId;
+    }
+
+    public function number() : string
+    {
+        return $this->number;
+    }
+
+    public function pullRequest() : bool
+    {
+        return $this->pullRequest;
+    }
+
+    public function pullRequestTitle() : string
+    {
+        return $this->pullRequestTitle;
+    }
+
+    public function pullRequestNumber() : string
+    {
+        return $this->pullRequestNumber;
+    }
+
+    public function config() : array
+    {
+        return $this->config;
+    }
+
+    public function state() : string
+    {
+        return $this->state;
+    }
+
+    public function startedAt() : DateTimeInterface
+    {
+        return $this->startedAt;
+    }
+
+    public function finishedAt() : DateTimeInterface
+    {
+        return $this->finishedAt;
+    }
+
+    public function duration() : int
+    {
+        return $this->duration;
+    }
+
+    public function jobIds() : array
+    {
+        return $this->jobIds;
+    }
+}

--- a/src/Resource/BuildInterface.php
+++ b/src/Resource/BuildInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WyriHaximus\Travis\Resource;
+
+use DateTimeInterface;
+
+/**
+ * @link https://docs.travis-ci.com/api#builds
+ */
+interface BuildInterface
+{
+    public function id() : int;
+
+    public function repositoryId() : int;
+
+    public function commitId() : int;
+
+    public function number() : string;
+
+    public function pullRequest() : bool;
+
+    public function pullRequestTitle() : string;
+
+    public function pullRequestNumber() : string;
+
+    public function config() : array;
+
+    public function state() : string;
+
+    public function startedAt() : DateTimeInterface;
+
+    public function finishedAt() : DateTimeInterface;
+
+    public function duration() : int;
+
+    public function jobIds() : array;
+}

--- a/tests/Resource/BuildTest.php
+++ b/tests/Resource/BuildTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WyriHaximus\Tests\Travis\Resource;
+
+use WyriHaximus\Travis\Resource\Build;
+use WyriHaximus\Travis\Resource\BuildInterface;
+
+class BuildTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsFinal()
+    {
+        $reflectionClass = new \ReflectionClass(Build::class);
+
+        $this->assertTrue($reflectionClass->isFinal());
+    }
+
+    public function testImplementsBuildInterface()
+    {
+        $build = new Build();
+
+        $this->assertInstanceOf(BuildInterface::class, $build);
+    }
+}


### PR DESCRIPTION
This PR
- [x] implements a representation of a build as a value object

:information_desk_person: We could use `zendframework/zend-hydrator` to hydrate this from the response body!
